### PR TITLE
Removed the need to load d3 globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Obtain a sunburst chart visualization for a personality profile.  For use in an 
 
 Include the library index.js script from the /dist folder and D3 in your HTML page.
 ```html
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.14/d3.min.js"></script>
-<script src="https://d3js.org/d3-color.v1.min.js"></script>
 <script src="path/to/index.js"></script> <!-- This is the file in the /dist folder. -->
 ```
 
@@ -56,6 +54,12 @@ This library is licensed under Apache 2.0. Full license text is
 available in [LICENSE](LICENSE).
 
 ## CHANGELOG
+
+__10-05-2017__
+ * Removed d3 from `window`
+ * Added to package.json:
+   * `"d3":"v3.5.14"`
+   * `"d3-color":"^1.0.3"`
 
 __26-01-2017__
  * Removed jQuery

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "watson"
   ],
   "dependencies": {
+    "d3": "^3.5.14",
+    "d3-color": "^1.0.3",
     "extend": "^3.0.0",
     "object.pick": "^1.2.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,8 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-/* global window, document */
- /**
+/* global document */
+/**
   * Renders the sunburst visualization. The parameter is the tree as returned
   * from the Personality Insights JSON API.
   */
@@ -28,19 +28,9 @@ const ChartRenderer = require('./personality-chart-renderer');
 const D3PersonalityProfileV2 = require('./d3-profile-wrappers/v2/index');
 const D3PersonalityProfileV3 = require('./d3-profile-wrappers/v3/index');
 const colors = require('./utilities/colors');
-
-// Dependencies check
-const dependencies = {
-  'd3' : 'D3js'
-};
-
-Object.keys(dependencies).forEach(function(dependency) {
-  if (typeof window[dependency] === 'undefined') {
-    throw new Error(dependencies[dependency] + ' is not present. Personality Sunburst Chart can\'t render without it.');
-  }
-});
-
-
+const d3 = require('d3');
+const d3Color = require('d3-color');
+Object.assign(d3, d3Color);
 
 class PersonalitySunburstChart {
 

--- a/src/personality-chart-renderer.js
+++ b/src/personality-chart-renderer.js
@@ -15,6 +15,9 @@
  */
 /* global alert */
 'use strict';
+const d3 = require('d3');
+const d3Color = require('d3-color');
+Object.assign(d3, d3Color);
 
 var d3SvgSingleArc = function() {
   var radius = d3_svg_singleArcRadius,


### PR DESCRIPTION
## Changes
- Added d3 and d3-color to package.json
- Load d3 and d3-color in every file that requires d3

## Rationale 
There were 2 reasons I felt the need to do this: 
1. To prevent a conflict between versions of D3 (v3 and v4).
2. We wanted to use this with React and not have to load stuff into onto the `window` variable