### PR TITLE
Fix viewbox position

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -76,7 +76,7 @@ class SunburstWidget {
     this.d3vis
       .attr('width', this.visualizationWidth)
       .attr('height', this.visualizationHeight)
-      .attr('viewBox', '0 -30 ' + this.dimH + ', ' + this.dimW);
+      .attr('viewBox', '0 0 ' + this.dimH + ', ' + this.dimW);
   }
 
   clear() {


### PR DESCRIPTION
This fixes the viewbox so that it is positioned at the origin and not given any padding at the top.  Any positioning of the visualization can be done via CSS.